### PR TITLE
✨ Feat: 관람객과 작가 정보 저장 및 그에 따른 뷰 플로우 연결

### DIFF
--- a/Projects/LastDance/LastDance.xcodeproj/project.pbxproj
+++ b/Projects/LastDance/LastDance.xcodeproj/project.pbxproj
@@ -40,6 +40,11 @@
 		99191E232EA199B300D2F71A /* SelectionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99191E222EA199B300D2F71A /* SelectionRow.swift */; };
 		99191E252EA199BB00D2F71A /* CustomAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99191E242EA199BB00D2F71A /* CustomAlert.swift */; };
 		99191E272EA199F300D2F71A /* View+CustomAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99191E262EA199F300D2F71A /* View+CustomAlert.swift */; };
+		99191E452EA1C43F00D2F71A /* ArtistReactionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99191E3F2EA1C43F00D2F71A /* ArtistReactionViewModel.swift */; };
+		99191E462EA1C43F00D2F71A /* ArtistReactionArchiveViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99191E3E2EA1C43F00D2F71A /* ArtistReactionArchiveViewModel.swift */; };
+		99191E472EA1C43F00D2F71A /* ArtistReactionArchiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99191E412EA1C43F00D2F71A /* ArtistReactionArchiveView.swift */; };
+		99191E482EA1C43F00D2F71A /* ArtistReactionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99191E422EA1C43F00D2F71A /* ArtistReactionView.swift */; };
+		99191E4C2EA1C8CF00D2F71A /* ArtistReactionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99191E4B2EA1C8CF00D2F71A /* ArtistReactionItem.swift */; };
 		99DAB0A82E9C48D700379F27 /* CameraPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DAB0A72E9C48D100379F27 /* CameraPreviewView.swift */; };
 		99DAB0AA2E9C490600379F27 /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DAB0A92E9C490300379F27 /* CameraManager.swift */; };
 		99DAB0AE2E9C4A2C00379F27 /* ShutterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DAB0AD2E9C4A2800379F27 /* ShutterButton.swift */; };
@@ -137,6 +142,11 @@
 		99191E222EA199B300D2F71A /* SelectionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionRow.swift; sourceTree = "<group>"; };
 		99191E242EA199BB00D2F71A /* CustomAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlert.swift; sourceTree = "<group>"; };
 		99191E262EA199F300D2F71A /* View+CustomAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+CustomAlert.swift"; sourceTree = "<group>"; };
+		99191E3E2EA1C43F00D2F71A /* ArtistReactionArchiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistReactionArchiveViewModel.swift; sourceTree = "<group>"; };
+		99191E3F2EA1C43F00D2F71A /* ArtistReactionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistReactionViewModel.swift; sourceTree = "<group>"; };
+		99191E412EA1C43F00D2F71A /* ArtistReactionArchiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistReactionArchiveView.swift; sourceTree = "<group>"; };
+		99191E422EA1C43F00D2F71A /* ArtistReactionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistReactionView.swift; sourceTree = "<group>"; };
+		99191E4B2EA1C8CF00D2F71A /* ArtistReactionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistReactionItem.swift; sourceTree = "<group>"; };
 		99DAB0A72E9C48D100379F27 /* CameraPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewView.swift; sourceTree = "<group>"; };
 		99DAB0A92E9C490300379F27 /* CameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraManager.swift; sourceTree = "<group>"; };
 		99DAB0AD2E9C4A2800379F27 /* ShutterButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShutterButton.swift; sourceTree = "<group>"; };
@@ -281,6 +291,33 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		99191E402EA1C43F00D2F71A /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				99191E3E2EA1C43F00D2F71A /* ArtistReactionArchiveViewModel.swift */,
+				99191E3F2EA1C43F00D2F71A /* ArtistReactionViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		99191E432EA1C43F00D2F71A /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				99191E412EA1C43F00D2F71A /* ArtistReactionArchiveView.swift */,
+				99191E422EA1C43F00D2F71A /* ArtistReactionView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		99191E442EA1C43F00D2F71A /* ArtistArchive */ = {
+			isa = PBXGroup;
+			children = (
+				99191E402EA1C43F00D2F71A /* ViewModel */,
+				99191E432EA1C43F00D2F71A /* Views */,
+			);
+			path = ArtistArchive;
+			sourceTree = "<group>";
+		};
 		99DAB0BD2E9EB77900379F27 /* Errors */ = {
 			isa = PBXGroup;
 			children = (
@@ -398,6 +435,7 @@
 				99E6F0AB2E91EF48002ED9C2 /* Camera */,
 				99E6F0AE2E91EF48002ED9C2 /* Reaction */,
 				99E6F0AA2E91EF48002ED9C2 /* Archive */,
+				99191E442EA1C43F00D2F71A /* ArtistArchive */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -476,6 +514,7 @@
 				99E6F0FE2E97B0C6002ED9C2 /* Exhibition.swift */,
 				99E6F0B32E91EF48002ED9C2 /* Item.swift */,
 				8C0F9F4B2E9CE192005B8C12 /* UserType.swift */,
+				99191E4B2EA1C8CF00D2F71A /* ArtistReactionItem.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -854,6 +893,7 @@
 				963573B42E9ABD4800B2FA79 /* BottomButton.swift in Sources */,
 				99DAB0AE2E9C4A2C00379F27 /* ShutterButton.swift in Sources */,
 				963573B02E9ABC6400B2FA79 /* CategoryButton.swift in Sources */,
+				99191E4C2EA1C8CF00D2F71A /* ArtistReactionItem.swift in Sources */,
 				99E6F0D82E91F2A3002ED9C2 /* OnboardingViewModel.swift in Sources */,
 				99E6F0BD2E91EFC0002ED9C2 /* NavigationRouter.swift in Sources */,
 				99E6F1072E97B0E0002ED9C2 /* Venue.swift in Sources */,
@@ -910,6 +950,10 @@
 				D8C7C0B12E9FEFD900FCB472 /* ReactionAPIService.swift in Sources */,
 				D8C7C0AB2E9F891500FCB472 /* BottomSheetType.swift in Sources */,
 				99E6F0B92E91EF48002ED9C2 /* Item.swift in Sources */,
+				99191E452EA1C43F00D2F71A /* ArtistReactionViewModel.swift in Sources */,
+				99191E462EA1C43F00D2F71A /* ArtistReactionArchiveViewModel.swift in Sources */,
+				99191E472EA1C43F00D2F71A /* ArtistReactionArchiveView.swift in Sources */,
+				99191E482EA1C43F00D2F71A /* ArtistReactionView.swift in Sources */,
 				8C3B37C62E9EB8DE003FF185 /* ArchiveView.swift in Sources */,
 				99E6F10B2E97B0EC002ED9C2 /* Reaction.swift in Sources */,
 				99191E232EA199B300D2F71A /* SelectionRow.swift in Sources */,

--- a/Projects/LastDance/LastDance/Sources/Common/Utils/Enum/Route.swift
+++ b/Projects/LastDance/LastDance/Sources/Common/Utils/Enum/Route.swift
@@ -24,4 +24,6 @@ enum Route: Hashable {
     case articleExhibitionList
     case articleList(selectedExhibitionId: String)
     case completeArticleList(selectedExhibitionId: String, selectedArtistId: Int)
+    case artistReaction
+    case artistReactionArchiveView
 }

--- a/Projects/LastDance/LastDance/Sources/Common/Utils/Enum/Route.swift
+++ b/Projects/LastDance/LastDance/Sources/Common/Utils/Enum/Route.swift
@@ -18,7 +18,7 @@ enum Route: Hashable {
     case artworkDetail(id: Int)
     case camera
     case inputArtworkInfo(image: UIImage)
-    case archive
+    case archive(id: String)
     case category
     case completeReaction
     case articleExhibitionList

--- a/Projects/LastDance/LastDance/Sources/Common/Utils/Enum/UserDefaultsKey.swift
+++ b/Projects/LastDance/LastDance/Sources/Common/Utils/Enum/UserDefaultsKey.swift
@@ -9,6 +9,7 @@
 enum UserDefaultsKey: String {
     case selectedCategories
     case seed = "seed.v1"
+    case userType
 
     var key: String {
         return self.rawValue

--- a/Projects/LastDance/LastDance/Sources/Presentation/Archive/Views/ArchiveView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/Archive/Views/ArchiveView.swift
@@ -12,6 +12,10 @@ struct ArchiveView: View {
     @StateObject private var viewModel = ArchiveViewModel()
     @EnvironmentObject private var router: NavigationRouter
     
+    
+    // TODO: - 이전 화면에서 넘겨받은 exhivitionId. 이것을 이용해 fetchCurrentExhibition 수정 필요.
+    let exhibitionId: String
+    
     var body: some View {
         VStack(spacing: 0) {
             ArchiveHeaderView {
@@ -142,10 +146,4 @@ struct ArchiveEmptyStateView: View {
             .lineSpacing(8)
             .frame(maxWidth: .infinity, minHeight: 400)
     }
-}
-
-#Preview {
-    ArchiveView()
-        .environmentObject(NavigationRouter())
-        .modelContainer(SwiftDataManager.shared.container!)
 }

--- a/Projects/LastDance/LastDance/Sources/Presentation/ArtistArchive/Views/ArtistReactionView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/ArtistArchive/Views/ArtistReactionView.swift
@@ -54,6 +54,7 @@ struct ArtistReactionView: View {
                         }
                         .frame(width: 155, height: 219)
                         .onTapGesture {
+                            router.push(.artistReactionArchiveView)
                         }
                         // 전시 제목
                         Text(viewModel.exhibitionTitle)

--- a/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionDetail/Views/ExhibitionDetailView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionDetail/Views/ExhibitionDetailView.swift
@@ -59,7 +59,6 @@ struct ExhibitionDetailView: View {
             initialUserType = UserType(rawValue: userTypeValue)
         }
         let isArtist = (initialUserType?.displayName == "작가")
-        print("\(isArtist)")
         let title = isArtist ? "내 전시가 맞아요" : "관람하기"
 
         return BottomButton(text: title) {

--- a/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionDetail/Views/ExhibitionDetailView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionDetail/Views/ExhibitionDetailView.swift
@@ -54,7 +54,7 @@ struct ExhibitionDetailView: View {
     
     var viewButton: some View {
         BottomButton(text: "관람하기") {
-            // TODO: 다음 화면으로 네비게이션
+            router.push(.archive(id: exhibitionId))
         }
         .padding(.horizontal, 20)
         .padding(.bottom, 34)

--- a/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionDetail/Views/ExhibitionDetailView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionDetail/Views/ExhibitionDetailView.swift
@@ -30,7 +30,7 @@ struct ExhibitionDetailView: View {
             }
             
             if viewModel.hasExhibition {
-                viewButton
+                actionButton
             }
         }
         .navigationBarTitleDisplayMode(.inline)
@@ -52,9 +52,22 @@ struct ExhibitionDetailView: View {
         }
     }
     
-    var viewButton: some View {
-        BottomButton(text: "관람하기") {
-            router.push(.archive(id: exhibitionId))
+    /// 관람객/작가에 따라 텍스트와 라우팅 분기
+    private var actionButton: some View {
+        var initialUserType: UserType?
+        if let userTypeValue = UserDefaults.standard.string(forKey: UserDefaultsKey.userType.key) {
+            initialUserType = UserType(rawValue: userTypeValue)
+        }
+        let isArtist = (initialUserType?.displayName == "작가")
+        print("\(isArtist)")
+        let title = isArtist ? "내 전시가 맞아요" : "관람하기"
+
+        return BottomButton(text: title) {
+            if isArtist {
+                router.push(.artistReaction)
+            } else {
+                router.push(.archive(id: exhibitionId))
+            }
         }
         .padding(.horizontal, 20)
         .padding(.bottom, 34)

--- a/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionList/ViewModel/CompleteArticleListViewModel.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionList/ViewModel/CompleteArticleListViewModel.swift
@@ -22,4 +22,37 @@ final class CompleteArticleListViewModel: ObservableObject {
         exhibition = allExhibitions.first { $0.id == exhibitionId }
         artist = allArtists.first { $0.id == artistId }
     }
+    
+    /// 현재 화면에 표시된 "작가명/전시명"으로 전시 id 찾기
+    func findExhibitionIdByCurrentFields() -> String? {
+        let allExhibitions = dataManager.fetchAll(Exhibition.self)
+        let allArtists = dataManager.fetchAll(Artist.self)
+
+        let artistName = (artist?.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let exhibitionTitle = (exhibition?.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !exhibitionTitle.isEmpty, !artistName.isEmpty else { return nil }
+
+        // 전시명으로 찾기
+        func norm(_ str: String) -> String { str.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+        let titleKey = norm(exhibitionTitle)
+
+        let candidates = allExhibitions.filter { norm($0.title) == titleKey }
+        guard !candidates.isEmpty else { return nil }
+
+        // 작가명으로 작가 찾고, 그 작가가 가진 exhibitions(id 리스트)와 교집합
+        guard let theArtist = allArtists.first(where: { norm($0.name) == norm(artistName) }) else { return nil }
+        let artistExhibitionIdSet = Set(theArtist.exhibitions)
+
+        // candidates 중에서 artist.exhibitions에 포함된 id만 남김
+        let narrowed = candidates.filter { artistExhibitionIdSet.contains($0.id) }
+
+        // 최종 선택
+        if let exact = narrowed.first {
+            return exact.id
+        } else {
+            // 작가와의 매칭이 없으면 전시명만으로라도 1건 반환 (정책에 따라 nil 리턴해도 됨)
+            return candidates.first?.id
+        }
+    }
 }

--- a/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionList/ViewModel/ExhibitionListViewModel.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionList/ViewModel/ExhibitionListViewModel.swift
@@ -26,6 +26,5 @@ final class ExhibitionListViewModel: ObservableObject {
             // TODO: 전시를 선택하지 않은 경우 예외 처리
             return
         }
-        // TODO: 다음 화면으로 네비게이션
     }
 }

--- a/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionList/Views/CompleteArticleListView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionList/Views/CompleteArticleListView.swift
@@ -20,10 +20,25 @@ struct CompleteArticleListInfoView: View {
 }
 
 struct CompleteArticleListFindButtonView: View {
+    @EnvironmentObject private var router: NavigationRouter
+    @ObservedObject var viewModel: CompleteArticleListViewModel
+    @State private var showNotFoundAlert = false
+    
     var body: some View {
         BottomButton(text: "전시 찾기") {
-            // TODO: 전시 찾기 기능
+            if let id = viewModel.findExhibitionIdByCurrentFields() {
+                // 전시 상세로 이동
+                router.push(.exhibitionDetail(id: id))
+            } else {
+                showNotFoundAlert = true
+            }
         }
+        .customAlert(
+            isPresented: $showNotFoundAlert,
+            title: "찾지 못했어요",
+            message: "작가명/전시명을 다시 확인해 주세요.",
+            buttonText: "확인"
+        ) { }
     }
 }
 
@@ -44,7 +59,7 @@ struct CompleteArticleListView: View {
             CompleteArticleListInfoView(viewModel: viewModel)   //실제 주입
                 .padding(.top, 14)
             Spacer()
-            CompleteArticleListFindButtonView()
+            CompleteArticleListFindButtonView(viewModel: viewModel)
         }
         .padding(.top, 18)
         .padding(.horizontal, 28)

--- a/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionList/Views/ExhibitionListView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/ExhibitionList/Views/ExhibitionListView.swift
@@ -27,8 +27,9 @@ struct ExhibitionListTitleSection: View {
 }
 
 struct ExhibitionListContent: View {
-    let exhibitions: [Exhibition]
     @ObservedObject var viewModel: ExhibitionListViewModel
+    
+    let exhibitions: [Exhibition]
 
     var body: some View {
         ScrollView {
@@ -47,11 +48,17 @@ struct ExhibitionListContent: View {
 }
 
 struct ExhibitionListRegisterButton: View {
+    @EnvironmentObject private var router: NavigationRouter
     @ObservedObject var viewModel: ExhibitionListViewModel
 
     var body: some View {
-        BottomButton(text: "등록하기") {
-            viewModel.tapRegisterButton()
+        BottomButton(
+            text: "등록하기",
+            isEnabled: viewModel.selectedExhibitionId != nil
+        ) {
+            if let exhibitionId = viewModel.selectedExhibitionId {
+                router.push(.exhibitionDetail(id: exhibitionId))
+            }
         }
     }
 }
@@ -65,7 +72,7 @@ struct ExhibitionListView: View {
         VStack(spacing: 0) {
             ExhibitionListTitleSection()
 
-            ExhibitionListContent(exhibitions: exhibitions, viewModel: viewModel)
+            ExhibitionListContent(viewModel: viewModel, exhibitions: exhibitions)
 
             Spacer()
 

--- a/Projects/LastDance/LastDance/Sources/Presentation/Onboarding/ViewModel/IdentitySelectionViewModel.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/Onboarding/ViewModel/IdentitySelectionViewModel.swift
@@ -26,7 +26,6 @@ final class IdentitySelectionViewModel: ObservableObject {
         }
 
         saveUserType(selectedType)
-        // TODO: 다음 온보딩 화면으로 네비게이션
     }
 
     /// 사용자 타입 저장
@@ -40,5 +39,6 @@ final class IdentitySelectionViewModel: ObservableObject {
             let newUser = User(role: type.rawValue)
             dataManager.insert(newUser)
         }
+        UserDefaults.standard.set(type.rawValue, forKey: UserDefaultsKey.userType.key)
     }
 }

--- a/Projects/LastDance/LastDance/Sources/Presentation/Onboarding/Views/ArticleArchivingView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/Onboarding/Views/ArticleArchivingView.swift
@@ -21,12 +21,15 @@ struct ArticleArchivingTitleSection: View {
 }
 
 struct ArticleArchivingAddButtonSection: View {
+    @EnvironmentObject private var router: NavigationRouter
+    
     let viewModel: ArchivingViewModel
 
     var body: some View {
         VStack(spacing: 40) {
             CircleAddButton {
                 viewModel.tapAddButton()
+                router.push(.articleExhibitionList)
             }
 
             Text("나의 작품에 어떤 반응을\n 남겼는지 확인해보세요")

--- a/Projects/LastDance/LastDance/Sources/Presentation/Onboarding/Views/AudienceArchivingView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/Onboarding/Views/AudienceArchivingView.swift
@@ -21,12 +21,14 @@ struct AudienceArchivingTitleSection: View {
 }
 
 struct AudienceArchivingAddButtonSection: View {
-    let viewModel: ArchivingViewModel
+    @EnvironmentObject private var router: NavigationRouter
+    @ObservedObject var viewModel: ArchivingViewModel
 
     var body: some View {
         VStack(spacing: 40) {
             CircleAddButton {
                 viewModel.tapAddButton()
+                router.push(.exhibitionList)
             }
 
             Text("전시 관람을 시작해 나만의\n전시 보관소를 만들어보세요")
@@ -40,7 +42,6 @@ struct AudienceArchivingAddButtonSection: View {
 
 /// 아카이빙 시작 뷰
 struct AudienceArchivingView: View {
-    @EnvironmentObject private var router: NavigationRouter
     @StateObject private var viewModel = ArchivingViewModel()
 
     var body: some View {

--- a/Projects/LastDance/LastDance/Sources/Presentation/Onboarding/Views/IdentitySelectionView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/Onboarding/Views/IdentitySelectionView.swift
@@ -21,7 +21,7 @@ struct IdentitySelectionTitleSection: View {
 }
 
 struct IdentitySelectionButtons: View {
-    let viewModel: IdentitySelectionViewModel
+    @ObservedObject var viewModel: IdentitySelectionViewModel
 
     var body: some View {
         VStack(spacing: 40) {
@@ -44,20 +44,31 @@ struct IdentitySelectionButtons: View {
 }
 
 struct IdentitySelectionNextButton: View {
-    let viewModel: IdentitySelectionViewModel
+    @EnvironmentObject private var router: NavigationRouter
+    @ObservedObject var viewModel: IdentitySelectionViewModel
 
     var body: some View {
-        BottomButton(text: "다음") {
+        BottomButton(
+            text: "다음",
+            isEnabled: viewModel.selectedType != nil
+        ) {
             viewModel.confirmSelection()
+            
+            guard let selectedType = viewModel.selectedType else { return }
+            switch selectedType {
+            case .artist:
+                router.push(.articleArchiving)
+            case .viewer:
+                router.push(.audienceArchiving)
+            }
         }
     }
 }
 
 /// 사용자 정체성 선택 뷰 (작가/관람객)
 struct IdentitySelectionView: View {
-    @EnvironmentObject private var router: NavigationRouter
     @StateObject private var viewModel = IdentitySelectionViewModel()
-
+    
     var body: some View {
         VStack(spacing: 28) {
             IdentitySelectionTitleSection()

--- a/Projects/LastDance/LastDance/Sources/Presentation/Root/RootView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/Root/RootView.swift
@@ -65,10 +65,19 @@ struct RootView: View {
                     InputArtworkInfoView(image: image)
                 case .articleExhibitionList:
                     ArticleExhibitionListView()
+                        .navigationBarBackButtonHidden(true)
                 case .articleList(let selectedExhibitionId):
                     ArticleListView(selectedExhibitionId: selectedExhibitionId)
+                        .navigationBarBackButtonHidden(true)
                 case .completeArticleList(let selectedExhibitionId, let selectedArtistId):
                     CompleteArticleListView(selectedExhibitionId: selectedExhibitionId, selectedArtistId: selectedArtistId)
+                        .navigationBarBackButtonHidden(true)
+                case .artistReaction:
+                    ArtistReactionView()
+                        .toolbar(.hidden, for: .navigationBar)
+                case .artistReactionArchiveView:
+                    ArtistReactionArchiveView()
+                        .toolbar(.hidden, for: .navigationBar)
                 }
             }
         }

--- a/Projects/LastDance/LastDance/Sources/Presentation/Root/RootView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/Root/RootView.swift
@@ -9,44 +9,68 @@ import SwiftUI
 
 struct RootView: View {
     @StateObject private var router = NavigationRouter()
-
+    @State private var userType: UserType?
+    
+    init() {
+        var initialUserType: UserType?
+        if let userTypeValue = UserDefaults.standard.string(forKey: UserDefaultsKey.userType.key) {
+            initialUserType = UserType(rawValue: userTypeValue)
+        }
+        _userType = State(initialValue: initialUserType)
+    }
+    
     var body: some View {
         NavigationStack(path: $router.path) {
-            OnboardingView()
-                .navigationDestination(for: Route.self) { route in
-                    switch route {
-                    case .identitySelection:
-                        IdentitySelectionView()
-                    case .audienceArchiving:
-                        AudienceArchivingView()
-                    case .articleArchiving:
+            Group {
+                if let userType = userType {
+                    switch userType {
+                    case .artist:
                         ArticleArchivingView()
-                    case .exhibitionList:
-                        ExhibitionListView()
-                    case .exhibitionDetail(let id):
-                        ExhibitionDetailView(exhibitionId: id)
-                            .navigationBarBackButtonHidden(true)
-                    case .artworkDetail(let id):
-                        ArtworkDetailView(artworkId: id)
-                    case .camera:
-                        CameraView()
-                            .toolbar(.hidden, for: .navigationBar)
-                    case .archive:
-                        ArchiveView()
-                    case .category:
-                        CategoryView()
-                    case .completeReaction:
-                        CompleteReactionView()
-                    case .inputArtworkInfo(let image):
-                        InputArtworkInfoView(image: image)
-                    case .articleExhibitionList:
-                        ArticleExhibitionListView()
-                    case .articleList(let selectedExhibitionId):
-                        ArticleListView(selectedExhibitionId: selectedExhibitionId)
-                    case .completeArticleList(let selectedExhibitionId, let selectedArtistId):
-                        CompleteArticleListView(selectedExhibitionId: selectedExhibitionId, selectedArtistId: selectedArtistId)
+                    case .viewer:
+                        AudienceArchivingView()
                     }
+                } else {
+                    IdentitySelectionView()
                 }
+            }
+            .navigationDestination(for: Route.self) { route in
+                switch route {
+                case .identitySelection:
+                    IdentitySelectionView()
+                case .audienceArchiving:
+                    AudienceArchivingView()
+                        .toolbar(.hidden, for: .navigationBar)
+                case .articleArchiving:
+                    ArticleArchivingView()
+                        .toolbar(.hidden, for: .navigationBar)
+                case .exhibitionList:
+                    ExhibitionListView()
+                        .toolbar(.hidden, for: .navigationBar)
+                case .exhibitionDetail(let id):
+                    ExhibitionDetailView(exhibitionId: id)
+                        .navigationBarBackButtonHidden(true)
+                case .artworkDetail(let id):
+                    ArtworkDetailView(artworkId: id)
+                case .camera:
+                    CameraView()
+                        .toolbar(.hidden, for: .navigationBar)
+                case .archive(let id):
+                    ArchiveView(exhibitionId: id)
+                        .toolbar(.hidden, for: .navigationBar)
+                case .category:
+                    CategoryView()
+                case .completeReaction:
+                    CompleteReactionView()
+                case .inputArtworkInfo(let image):
+                    InputArtworkInfoView(image: image)
+                case .articleExhibitionList:
+                    ArticleExhibitionListView()
+                case .articleList(let selectedExhibitionId):
+                    ArticleListView(selectedExhibitionId: selectedExhibitionId)
+                case .completeArticleList(let selectedExhibitionId, let selectedArtistId):
+                    CompleteArticleListView(selectedExhibitionId: selectedExhibitionId, selectedArtistId: selectedArtistId)
+                }
+            }
         }
         .environmentObject(router)
     }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- UserDefault에 작가/관람객 정보 저장
- 작가 플로우 연결
- 관람객 플로우 연결

---

### 📸 스크린샷 
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

둘 다 첫 화면에서 각자 역할을 선택한 상태에서 진행되는 흐름입니다.

- 관람객 플로우

https://github.com/user-attachments/assets/3c7000ee-dcd7-4272-950c-52d47a7d6cda

- 작가 플로우

https://github.com/user-attachments/assets/50c6c2c7-d971-44a2-a3b2-d50855b7241d

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26.0 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 데이터 연동
처음 작가/관람객 정보 저장 이후로 뷰 간의 데이터 연동이 된 곳이있고 아직 안된 상태로 목데이터를 활용하는 부분이 있습니다.
뷰 연결 자체에 집중해 구현해둔 상태로, 광로가 이전에 수정하겠다고 하셨던 부분들 수정해주시면 나머지 연결 가능할것같습니다.

- 뷰전환 위치
현재 view에서 뷰전환이 이뤄지고 있습니다.
MVVM 패턴에 맞게 VeiwModel에서 뷰전환 이뤄지도록 추후에 수정하면 좋을 것 같습니다.
빠르게 해야하는 것들 먼저 수행한 이후에 수정하도록 하겠습니다.
