### PR TITLE
🐛 Fix: 재촬영시 뷰파인더 배율 유지 되도록 개선

### DIFF
--- a/Projects/LastDance/LastDance/Sources/Common/Manager/CameraManager.swift
+++ b/Projects/LastDance/LastDance/Sources/Common/Manager/CameraManager.swift
@@ -10,6 +10,9 @@ import UIKit
 
 final class CameraManager: NSObject, @unchecked Sendable {
     let session = AVCaptureSession()
+    var onFirstFrame: (() -> Void)?
+
+    private var didSendFirstFrame = false
     private let sessionQueue = DispatchQueue(label: "camera.session.queue")
     private var videoDeviceInput: AVCaptureDeviceInput?
     private let photoOutput = AVCapturePhotoOutput()
@@ -33,7 +36,7 @@ final class CameraManager: NSObject, @unchecked Sendable {
     }
 
     // MARK: - Configure (rear-only)
-    func configureIfNeeded() async throws {
+    func configureIfNeeded(initialZoomScale: CGFloat? = nil) async throws {
         guard !isConfigured else { return }
         guard Self.checkAuthorizationStatus() == .authorized else {
             throw CameraManagerError.unauthorized
@@ -53,6 +56,24 @@ final class CameraManager: NSObject, @unchecked Sendable {
                     if self.session.canAddInput(input) { self.session.addInput(input) }
                     self.videoDeviceInput = input
 
+                    // 초기 줌 값 적용
+                    if let initialZoomScale {
+                        // UI 스케일을 디바이스 줌으로 변환
+                        let targetZoomFactor = self.deviceZoomFactor(fromUIScale: initialZoomScale)
+                        do {
+                            try device.lockForConfiguration()
+                            let clamped = max(
+                                device.minAvailableVideoZoomFactor,
+                                min(targetZoomFactor,
+                                    device.maxAvailableVideoZoomFactor)
+                            )
+                            device.videoZoomFactor = clamped
+                            device.unlockForConfiguration()
+                        } catch {
+                            Log.error("initial zoom set failed: \(error)")
+                        }
+                    }
+                    
                     if self.session.canAddOutput(self.photoOutput) {
                         self.session.addOutput(self.photoOutput)
 
@@ -94,13 +115,11 @@ final class CameraManager: NSObject, @unchecked Sendable {
 
     // MARK: - Start/Stop
     func startRunning() {
-        sessionQueue.async { if !self.session.isRunning { self.session.startRunning() } }
-        
-        // 초기 줌 배율을 1로 유지하기 위함
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { [weak self] in
-            guard let self else { return }
-            self.setZoomScale(1.001, animated: false)
-            self.setZoomScale(1.0, animated: false)
+        sessionQueue.async {
+            if !self.session.isRunning {
+                self.didSendFirstFrame = false
+                self.session.startRunning()
+            }
         }
     }
     
@@ -225,9 +244,17 @@ private final class PhotoCaptureProcessor: NSObject, AVCapturePhotoCaptureDelega
 
 // MARK: - 영상 촬영을 위한 delegate
 extension CameraManager: AVCaptureVideoDataOutputSampleBufferDelegate {
-    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer,
+    func captureOutput(_ output: AVCaptureOutput,
+                       didOutput sampleBuffer: CMSampleBuffer,
                        from connection: AVCaptureConnection) {
         lastVideoBuffer = sampleBuffer
+        
+        if !didSendFirstFrame {
+            didSendFirstFrame = true
+            DispatchQueue.main.async { [weak self] in
+                self?.onFirstFrame?()
+            }
+        }
     }
 }
 
@@ -281,6 +308,11 @@ extension CameraManager {
             if device.isRampingVideoZoom { device.cancelVideoZoomRamp() }
             device.unlockForConfiguration()
         } catch { }
+    }
+    
+    /// UI 스케일을 디바이스 실제 줌팩터로 변환
+    fileprivate func deviceZoomFactor(fromUIScale uiScale: CGFloat) -> CGFloat {
+        uiScale * uiToDeviceFactor
     }
 }
 

--- a/Projects/LastDance/LastDance/Sources/Common/Utils/Enum/PreviewPhase.swift
+++ b/Projects/LastDance/LastDance/Sources/Common/Utils/Enum/PreviewPhase.swift
@@ -1,0 +1,39 @@
+//
+//  PreviewPhase.swift
+//  LastDance
+//
+//  Created by 배현진 on 11/8/25.
+//
+
+import CoreFoundation
+
+/// 카메라 Preview 보여주는 상태 변경을 위한 enum
+enum PreviewPhase: Int {
+    case hidden      // 안보여줌
+    case blurred     // 흐릿하게 보임
+    case visible     // 안보임
+
+    var blurRadius: CGFloat {
+        switch self {
+        case .hidden:  return 15
+        case .blurred: return 8
+        case .visible: return 0
+        }
+    }
+
+    var opacity: Double {
+        switch self {
+        case .hidden:  return 0.0
+        case .blurred: return 1.0
+        case .visible: return 1.0
+        }
+    }
+
+    var animationDuration: Double {
+        switch self {
+        case .hidden:  return 0.0
+        case .blurred: return 0.45
+        case .visible: return 0.45
+        }
+    }
+}

--- a/Projects/LastDance/LastDance/Sources/Presentation/Camera/ViewModel/CameraViewModel.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/Camera/ViewModel/CameraViewModel.swift
@@ -27,7 +27,7 @@ final class CameraViewModel: ObservableObject {
         do {
             try await requestCameraAuthorization()
             try await configureCaptureSession()
-            startSession()
+            await startSession()
             
             if !hasShownSilentNotice {
                 hasShownSilentNotice = true
@@ -39,9 +39,15 @@ final class CameraViewModel: ObservableObject {
     }
 
     /// 카메라 세션 시작
-    func startSession() {
+    func startSession() async {
         manager.startRunning()
         isRunning = true
+        
+        try? await Task.sleep(for: .milliseconds(100))
+        
+        if zoomScale != 1.0 {
+            selectZoomScale(zoomScale, animated: false)
+        }
     }
 
     /// 카메라 세션 중지

--- a/Projects/LastDance/LastDance/Sources/Presentation/Camera/ViewModel/CameraViewModel.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/Camera/ViewModel/CameraViewModel.swift
@@ -33,7 +33,7 @@ final class CameraViewModel: ObservableObject {
             manager.onFirstFrame = { [weak self] in
                 guard let self else { return }
                 self.previewPhase = .blurred
-                Task { @MainActor in
+                Task {
                     try? await Task.sleep(for: .milliseconds(400))
                     self.previewPhase = .visible
                 }

--- a/Projects/LastDance/LastDance/Sources/Presentation/Camera/Views/CameraView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/Camera/Views/CameraView.swift
@@ -112,8 +112,12 @@ private struct Preview: View {
                         }
                     )
                     .viewfinderCorners(length: 21, lineWidth: 3, color: LDColor.color6, inset: 2)
-                    .blur(radius: viewModel.isReadyForPreview ? 0 : 30)
-                    .animation(.easeInOut(duration: 0.6), value: viewModel.isReadyForPreview)
+                    .blur(radius: viewModel.previewPhase.blurRadius)
+                    .opacity(viewModel.previewPhase.opacity)
+                    .animation(
+                        .easeInOut(duration: viewModel.previewPhase.animationDuration),
+                        value: viewModel.previewPhase
+                    )
                 } else {
                     Color.black
                         .overlay(

--- a/Projects/LastDance/LastDance/Sources/Presentation/Camera/Views/CameraView.swift
+++ b/Projects/LastDance/LastDance/Sources/Presentation/Camera/Views/CameraView.swift
@@ -112,6 +112,8 @@ private struct Preview: View {
                         }
                     )
                     .viewfinderCorners(length: 21, lineWidth: 3, color: LDColor.color6, inset: 2)
+                    .blur(radius: viewModel.isReadyForPreview ? 0 : 30)
+                    .animation(.easeInOut(duration: 0.6), value: viewModel.isReadyForPreview)
                 } else {
                     Color.black
                         .overlay(


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 촬용 이후 이미지 확인 뷰에서 재촬영 버튼을 눌러 카메라로 돌아갔을 경우 이전 배율 유지

---

### 📸 스크린샷 
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

- 배율을 유지하며 카메라로 복귀하다보니, 카메라가 다시 셋팅되어야 할 필요가 있었고, 그 결과 깜빡이는 것처럼 보이는 현상이 발생했습니다.
다양한 방식을 시도해 어색함을 최소화하고자 했고, 우선 3번으로 적용해두었습니다.
다른 팀원분들의 생각도 궁금합니다~

- 0. 문제 상황 (배율 유지시 깜빡임 발생)

https://github.com/user-attachments/assets/c7a47c07-b349-497f-91ca-34845bd6ea99

- 1. 셋팅 시간 지연동안 black 처리 (깜빡임 티는 안나지만, 먹통인 느낌을 가질 수 있음)

https://github.com/user-attachments/assets/a797b04d-e41f-476a-9956-82ddaafd41cd

- 2. 셋팅 시간 지연동안 blur 처리 (깜빡임 티남)

https://github.com/user-attachments/assets/43b5a1ca-b3f2-46e0-b366-679fa924d9ed


- 3. 셋팅 시간 지연동안 black -> blur 처리

https://github.com/user-attachments/assets/c29f0bd7-157f-445a-80e3-9755296137d7


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 14 Pro, iOS 18.0 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 원래 배율 컨트롤러만 유지되고 있던 부분을 카메라 뷰파인더 자체의 배율에도 적용되도록 개선했습니다.
이 과정에서 카메라 깜빡임이 발생하고 있고, 여러 방식으로 깜빡임을 최소화해보았습니다. 
스크린샷 확인하고 의견 나눔 부탁드려요~

(이미지 confirm 하는 순간까지도 카메라 세션을 유지하면, 깜빡임 없이 셋팅될 수 있을 겁니다.
하지만, confirm을 위해 다른 뷰로 넘어가있는 동안 세션 진행 (카메라 on 모드임이 상단 바에서 들어남) 모드로 두는것도
맞지않는 플로우라고 생각해, 현재 상태에서 최대한 티가 나지않게 처리해보았습니다. )
