### PR TITLE
🐛 [fix] 앱클립 타켓에 다국어지원 타입 적용

### DIFF
--- a/Projects/LastDance/LastDance.xcodeproj/project.pbxproj
+++ b/Projects/LastDance/LastDance.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 			membershipExceptions = (
 				Resources/Badword/badword_filter.txt,
 				Sources/Common/Components/CachedImage.swift,
+				Sources/Common/Components/SnappingScrollView.swift,
 				"Sources/Common/Extensions/Date+Extensions.swift",
 				Sources/Common/Extensions/Log.swift,
 				"Sources/Common/Extensions/Navigation+Extension.swift",
@@ -473,7 +474,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.3.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.LastDance.Clip;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -515,7 +516,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.3.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.LastDance.Clip;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -683,7 +684,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.3.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.LastDance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -728,7 +729,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.3.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.LastDance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Projects/LastDance/LastDance/Resources/Localizable.xcstrings
+++ b/Projects/LastDance/LastDance/Resources/Localizable.xcstrings
@@ -746,6 +746,7 @@
       }
     },
     "작자미상" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -846,6 +847,7 @@
       }
     },
     "전시 계속 보기" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Projects/LastDance/LastDanceClip/Sources/View/ClipArtReactionView.swift
+++ b/Projects/LastDance/LastDanceClip/Sources/View/ClipArtReactionView.swift
@@ -100,7 +100,7 @@ struct ClipArtReactionView: View {
                         didSnap = false
                     }
                 }
-                .background(LDColor.color6)
+                .background(Color.white)
                 
             } else {
                 // 처음 로딩 상태

--- a/Projects/LastDance/LastDanceClip/Sources/View/ClipCustomAlert.swift
+++ b/Projects/LastDance/LastDanceClip/Sources/View/ClipCustomAlert.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 struct ClipCustomAlert: View {
     let image: String
-    let title: String
-    let message: String
-    let buttonText: String
+    let title: LocalizedStringKey
+    let message: LocalizedStringKey?
+    let buttonText: LocalizedStringKey
     let action: () -> Void
     let cancelAction: (() -> Void)?  // 취소 버튼 액션 (옵셔널)
 
@@ -35,7 +35,7 @@ struct ClipCustomAlert: View {
                 .padding(.horizontal, 16)
 
             // 메시지가 있을 때만 보여주기
-            if !message.isEmpty {
+            if let message = message {
                 Text(message)
                     .font(.system(size: 14, weight: .regular))
                     .foregroundColor(Color(red: 0.39, green: 0.39, blue: 0.39))
@@ -45,7 +45,7 @@ struct ClipCustomAlert: View {
             }
 
             // 메시지가 있을 때만 아래 spacer 유지
-            if !message.isEmpty {
+            if let message = message {
                 Spacer().frame(height: 22)
             } else {
                 Spacer().frame(height: 22)  // 타이틀-only 버전용 약간의 여백 조정
@@ -99,9 +99,9 @@ struct ClipCustomAlert: View {
 struct CustomAlertModifier: ViewModifier {
     @Binding var isPresented: Bool
     let image: String
-    let title: String
-    let message: String
-    let buttonText: String
+    let title: LocalizedStringKey
+    let message: LocalizedStringKey?
+    let buttonText: LocalizedStringKey
     let action: () -> Void
     let cancelAction: (() -> Void)?
 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?

close #127 

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 다국어 지원으로 인해 앱클립 타겟에서 발생하는 오류 수정

---

### 📸 스크린샷 
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

X
---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 14pro, iOS 18.0 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 다국어 지원 앱클립 적용 x
현재 앱클립 자체는 다국어 지원을 안하고 있습니다.
우선 customAlert에서 발생하는 오류만 수정했습니다.
